### PR TITLE
Feature/better autoloader handling

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -2,81 +2,148 @@
 
 namespace EdpSuperluminal;
 
-use Zend\EventManager\StaticEventManager;
+use Zend\Code\Reflection\ClassReflection,
+    Zend\EventManager\StaticEventManager;
 
+/**
+ * Create a class cache of all classes used.
+ *
+ * @package EdpSuperluminal
+ */
 class Module
 {
+    /**
+     * Attach events
+     * 
+     * @return void
+     */
     public function init()
     {
         $events = StaticEventManager::getInstance();
-        // This is a total mess, I know. Just wanted to flesh out the logic.
-        // @TODO: Refactor into a class, clean up logic, DRY it up, maybe move 
-        // some of this into Zend\Code
-        $events->attach('Zend\Mvc\Application', 'finish', function($e) {
-            if (!$e->getRequest()->query()->get('buildCache') || file_exists(ZF_CLASS_CACHE)) return;
-            $getCacheCode = function ($r)
-            {
-                $useString = '';
-                $usesNames = array();
-                if (count($uses = $r->getDeclaringFile()->getUses())) { 
-                    $useString = "\nuse ";
-                    $lastUse = array_pop($uses);
-                    foreach ($uses as $use) {
-                        $usesNames[$use['use']] = $use['as'];
-                        $useString .= "{$use['use']}";
-                        if ($use['as']) {
-                            $useString .= " as {$use['as']}";
-                        }
-                        $useString .= ",\n";
-                    }
-                    $usesNames[$lastUse['use']] = $lastUse['as'];
-                    $useString .= "{$lastUse['use']}";
-                    if ($lastUse['as']) {
-                        $useString .= " as {$lastUse['as']}";
-                    }
-                    $useString .= ";\n\n";
-                }
-                $declaration = '';
-                if ($r->isAbstract() 
-                    && !$r->isInterface())  $declaration .= 'abstract ';
-                if ($r->isFinal())          $declaration .= 'final ';
-                if ($r->isInterface())      $declaration .= 'interface ';
-                if (!$r->isInterface())     $declaration .= 'class ';
-                $declaration .= $r->getShortName();
-                if ($parent = $r->getParentClass()) {
-                    $parentName = array_key_exists($parent->getName(), $usesNames) ? ($usesNames[$parent->getName()] ?: $parent->getShortName()) : ((0 === strpos($parent->getName(), $r->getNamespaceName())) ? substr($parent->getName(), strlen($r->getNamespaceName()) + 1) : '\\' . $parent->getName()); 
-                    $declaration .= " extends {$parentName}";
-                }
-                if (count($interfaces = array_diff($r->getInterfaceNames(), $parent ? $parent->getInterfaceNames() : array()))) {
-                    foreach ($interfaces as $interface) {
-                        $iReflection = new \Zend\Code\Reflection\ClassReflection($interface);
-                        $interfaces = array_diff($interfaces, $iReflection->getInterfaceNames());
-                    }
-                    $declaration .= $r->isInterface() ? ' extends ' : ' implements ';
-                    $declaration .= implode(', ', array_map(function($interface) use ($usesNames, $r) {
-                            $iReflection = new \Zend\Code\Reflection\ClassReflection($interface);
-                            return (array_key_exists($iReflection->getName(), $usesNames) ? ($usesNames[$iReflection->getName()] ?: $iReflection->getShortName()) : ((0 === strpos($iReflection->getName(), $r->getNamespaceName())) ? substr($iReflection->getName(), strlen($r->getNamespaceName()) + 1) : '\\' . $iReflection->getName()));
-            
-                        }, $interfaces)
-                    );
-                }
-                return "\nnamespace " 
-                     . $r->getNamespaceName()
-                     . " {\n"
-                     . $useString
-                     . $declaration . "\n"
-                     . strstr($r->getContents(false), '{') // messes up when 'implements' is on separate line
-                     . "\n}\n";
-            };
-     
-            $classes = array_merge(get_declared_interfaces(), get_declared_classes());
-            $code = "<?php\n";
-            foreach ($classes as $class) {
-                if (0 !== strpos($class, 'Zend\\')) continue;
-                $class = new \Zend\Code\Reflection\ClassReflection($class);
-                $code .= $getCacheCode($class);
+        $events->attach('Zend\Mvc\Application', 'finish', array($this, 'cache'));
+    }
+
+    /**
+     * Cache declared interfaces and classes to a single file
+     * 
+     * @param  \Zend\Mvc\MvcEvent $e 
+     * @return void
+     */
+    public function cache($e)
+    {
+        if (!$e->getRequest()->query()->get('buildCache') 
+            || file_exists(ZF_CLASS_CACHE)
+        ) {
+            return;
+        }
+    
+        $classes = array_merge(get_declared_interfaces(), get_declared_classes());
+        $code = "<?php\n";
+        foreach ($classes as $class) {
+            if (0 !== strpos($class, 'Zend\\')) {
+                // Skip ZF classes
+                continue;
             }
-            file_put_contents(ZF_CLASS_CACHE, $code);
-        });
+
+            $class = new ClassReflection($class);
+            $code .= static::getCacheCode($class);
+        }
+
+        file_put_contents(ZF_CLASS_CACHE, $code);
+    }
+
+    /**
+     * Generate code to cache from class reflection.
+     *
+     * This is a total mess, I know. Just wanted to flesh out the logic.
+     * @todo Refactor into a class, clean up logic, DRY it up, maybe move 
+     *       some of this into Zend\Code
+     * @param  ClassReflection $r
+     * @return string
+     */
+    protected static function getCacheCode(ClassReflection $r)
+    {
+        $useString = '';
+        $usesNames = array();
+        if (count($uses = $r->getDeclaringFile()->getUses())) { 
+            $useString = "\nuse ";
+            $lastUse   = array_pop($uses);
+
+            foreach ($uses as $use) {
+                $usesNames[$use['use']] = $use['as'];
+
+                $useString .= "{$use['use']}";
+
+                if ($use['as']) {
+                    $useString .= " as {$use['as']}";
+                }
+
+                $useString .= ",\n";
+            }
+
+            $usesNames[$lastUse['use']] = $lastUse['as'];
+            $useString .= "{$lastUse['use']}";
+
+            if ($lastUse['as']) {
+                $useString .= " as {$lastUse['as']}";
+            }
+
+            $useString .= ";\n\n";
+        }
+
+        $declaration = '';
+
+        if ($r->isAbstract() && !$r->isInterface()) {
+            $declaration .= 'abstract ';
+        }
+
+        if ($r->isFinal()) {
+            $declaration .= 'final ';
+        }
+
+        if ($r->isInterface()) {
+            $declaration .= 'interface ';
+        }
+
+        if (!$r->isInterface()) {
+            $declaration .= 'class ';
+        }
+
+        $declaration .= $r->getShortName();
+
+        if ($parent = $r->getParentClass()) {
+            $parentName   = array_key_exists($parent->getName(), $usesNames) 
+                          ? ($usesNames[$parent->getName()] ?: $parent->getShortName()) 
+                          : ((0 === strpos($parent->getName(), $r->getNamespaceName())) 
+                            ? substr($parent->getName(), strlen($r->getNamespaceName()) + 1) 
+                            : '\\' . $parent->getName()); 
+
+            $declaration .= " extends {$parentName}";
+        }
+
+        $interfaces = array_diff($r->getInterfaceNames(), $parent ? $parent->getInterfaceNames() : array());
+        if (count($interfaces)) {
+            foreach ($interfaces as $interface) {
+                $iReflection = new ClassReflection($interface);
+                $interfaces  = array_diff($interfaces, $iReflection->getInterfaceNames());
+            }
+            $declaration .= $r->isInterface() ? ' extends ' : ' implements ';
+            $declaration .= implode(', ', array_map(function($interface) use ($usesNames, $r) {
+                $iReflection = new ClassReflection($interface);
+                return (array_key_exists($iReflection->getName(), $usesNames) 
+                       ? ($usesNames[$iReflection->getName()] ?: $iReflection->getShortName()) 
+                       : ((0 === strpos($iReflection->getName(), $r->getNamespaceName())) 
+                         ? substr($iReflection->getName(), strlen($r->getNamespaceName()) + 1) 
+                         : '\\' . $iReflection->getName()));
+            }, $interfaces));
+        }
+
+        return "\nnamespace " 
+               . $r->getNamespaceName()
+               . " {\n"
+               . $useString
+               . $declaration . "\n"
+               . strstr($r->getContents(false), '{') // messes up when 'implements' is on separate line
+               . "\n}\n";
     }
 }

--- a/README.md
+++ b/README.md
@@ -18,10 +18,13 @@ Installation
 ------------
 
 - Clone this module into your `vendor/` directory and enable `EdpSuperluminal`
-- Add the following code to your `public/index.php` after chdir() and immediately following the AutoloaderFactory::factory invocation:
+- Add the following code to your `public/index.php` after chdir() and
+  immediately following the AutoloaderFactory::factory invocation:
 
         define('ZF_CLASS_CACHE', 'data/cache/classes.php.cache');
         if (file_exists(ZF_CLASS_CACHE)) require_once ZF_CLASS_CACHE;
 
 - In your browser, go to http://yourapp/?buildCache=1 to build the initial
-  class.
+  class. You should do this for any page that is (a) dependency heavy, and/or
+  (b) every page with a different dependency graph. Each call will append to
+  the cache with any newly discovered classes.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Installation
 ------------
 
 - Clone this module into your `vendor/` directory and enable `EdpSuperluminal`
-- Add the following code to your `public/index.php` after chdir() and before including the AutoloaderFactory file:
+- Add the following code to your `public/index.php` after chdir() and immediately following the AutoloaderFactory::factory invocation:
 
         define('ZF_CLASS_CACHE', 'data/cache/classes.php.cache');
         if (file_exists(ZF_CLASS_CACHE)) require_once ZF_CLASS_CACHE;


### PR DESCRIPTION
These commits achieve several things:
- First, they omit autoloaders and the superluminal module from caching, which corrects some errors I was seeing.
- Second, they munge **DIR** in cached file contents to resolve to the directory the original class file occurred in (fixes issues with retrieving module configuration and/or classmaps).
- Third, the code now allows appending the cache, which means you can gradually build the cache over a number of requests.
- Finally, the require_once for the cache file should now occur _after_ the autoloader factory runs, in order to ensure that classes referenced by cached files but not cached themselves may be discovered. (edge case)

I've tested on a local copy of my site, and all is working correctly now. I'm only seeing ~10% gains, but even a 10% gain is worthwhile.
