### PR TITLE
Ignoring ConsoleRequests

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -5,6 +5,7 @@ namespace EdpSuperluminal;
 use Zend\Code\Reflection\ClassReflection,
     Zend\Code\Scanner\FileScanner,
     Zend\EventManager\StaticEventManager;
+use Zend\Console\Request as ConsoleRequest;
 
 /**
  * Create a class cache of all classes used.
@@ -34,7 +35,9 @@ class Module
      */
     public function cache($e)
     {
-        if ($e->getRequest()->getQuery()->get('EDPSUPERLUMINAL_CACHE', null) === null) {
+        $request = $e->getRequest();
+        if ($request instanceof ConsoleRequest ||
+            $request->getQuery()->get('EDPSUPERLUMINAL_CACHE', null) === null) {
             return;
         }
 


### PR DESCRIPTION
when we has EdpSuperLuminal module included in our application config and trying call some console requests (http://packages.zendframework.com/docs/latest/manual/en/modules/zend.console.introduction.html) we got bug. This is a simple fix for this.
