### PR TITLE
Skip Annotaion classes in the caching

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -72,6 +72,13 @@ class Module
 
             $class = new ClassReflection($class);
 
+            // Skip any Annotation classes
+            $docBlock = $class->getDocBlock();
+            if ($docBlock) {
+                if ($docBlock->getTags('Annotation'))
+                    continue;
+            }
+
             // Skip ZF2-based autoloaders
             if (in_array('Zend\Loader\SplAutoloader', $class->getInterfaceNames())) {
                 continue;


### PR DESCRIPTION
Using form Annotation in Entities was not working as comments are being dropped.

Just a quick addition to skip Zend classes, particularly Zend\Form\Annotation*
